### PR TITLE
Exclude iOS devices from vr demo

### DIFF
--- a/player/vr-360/css/style.css
+++ b/player/vr-360/css/style.css
@@ -10,6 +10,23 @@ div.input-hint {
     display: none;
 }
 
+#player.is-unsupported {
+    height: 100%;
+    margin: 15px 0;
+}
+
+#player.is-unsupported #player-container {
+    min-height: 150px;
+    min-width: 260px;
+    display: flex;
+    align-items: center;
+}
+
+.message-not-supported {
+    padding: 0 60px;
+    font-size: 18px;
+}
+
 @media (min-width: 991px) {
     div.input-hint {
         margin-top: 30px;
@@ -81,4 +98,11 @@ body .demo-detail .description {
 body:not(.fullscreen) :not(.no-frame).phone-frame::before {
     top: 0;
     left: 0;
+}
+
+@media (max-width: 767px) {
+    .message-not-supported {
+        border: 1px solid #dee2e6;
+        padding: 20px;
+    }
 }

--- a/player/vr-360/js/script.js
+++ b/player/vr-360/js/script.js
@@ -2,7 +2,7 @@ function isIOS() {
   return /iPad|iPhone|iPod/.test(navigator.platform);
 };
 
-if (!isIOS()) {
+if (isIOS()) {
   showNotSupportedMessage();
 } else {
   setupPlayer();

--- a/player/vr-360/js/script.js
+++ b/player/vr-360/js/script.js
@@ -1,29 +1,55 @@
-var conf = {
-  key: '29ba4a30-8b5e-4336-a7dd-c94ff3b25f30',
-  analytics: {
-    key: '45adcf9b-8f7c-4e28-91c5-50ba3d442cd4',
-    videoId: 'vr-360'
-  },
-  style: {
-    aspectratio: '2:1'
-  },
-  playback: {
-    muted: true
-  }
+function isIOS() {
+  return /iPad|iPhone|iPod/.test(navigator.platform);
 };
 
-var source = {
-  dash: 'https://bitmovin-a.akamaihd.net/content/playhouse-vr/mpds/105560.mpd',
-  hls: 'https://bitmovin.com/player-content/playhouse-vr/m3u8s/105560.m3u8',
-  progressive: 'https://bitmovin.com/player-content/playhouse-vr/progressive.mp4',
-  poster: 'https://bitmovin-a.akamaihd.net/content/playhouse-vr/poster.jpg',
-  vr: {
-    startupMode: '2d',
-    startPosition: 180
-  }
-};
+if (!isIOS()) {
+  showNotSupportedMessage();
+} else {
+  setupPlayer();
+}
 
-var playerContainer = document.getElementById('player-container');
-var  player = new bitmovin.player.Player(playerContainer, conf);
+function showNotSupportedMessage() {
+  var message = 'This demo is not currently available on iOS as we’re working to enhance this VR/360 demo. Please get in touch if you’d like to learn more.';
 
-player.load(source);
+  var container = document.getElementById('player-container');
+  var player = document.getElementById('player');
+  var messageContainer = document.createElement('div');
+
+  messageContainer.setAttribute('class', 'message-not-supported')
+  messageContainer.textContent = message
+
+  container.append(messageContainer);
+  player.classList.add('is-unsupported');
+}
+
+function setupPlayer() {
+  var conf = {
+    key: '29ba4a30-8b5e-4336-a7dd-c94ff3b25f30',
+    analytics: {
+      key: '45adcf9b-8f7c-4e28-91c5-50ba3d442cd4',
+      videoId: 'vr-360'
+    },
+    style: {
+      aspectratio: '2:1'
+    },
+    playback: {
+      muted: true
+    }
+  };
+  
+  var source = {
+    dash: 'https://bitmovin-a.akamaihd.net/content/playhouse-vr/mpds/105560.mpd',
+    hls: 'https://bitmovin.com/player-content/playhouse-vr/m3u8s/105560.m3u8',
+    progressive: 'https://bitmovin.com/player-content/playhouse-vr/progressive.mp4',
+    poster: 'https://bitmovin-a.akamaihd.net/content/playhouse-vr/poster.jpg',
+    vr: {
+      startupMode: '2d',
+      startPosition: 180
+    }
+  };
+  
+  var playerContainer = document.getElementById('player-container');
+  var player = new bitmovin.player.Player(playerContainer, conf);
+  
+  player.load(source);
+}


### PR DESCRIPTION
Issue: https://bitmovin.atlassian.net/browse/PW-4659

Currently iOS devices cannot play our VR-360 demo.
This PR excludes iOS devices and shows the message This demo is not currently available on iOS as we’re working to enhance this VR/360 demo. Please get in touch if you’d like to learn more. instead.

A separate web player issue will be created that deals with investigation and implementation of a fix.