### PR TITLE
Fix Playready DRM demo not rendering video content due to border-radius style property

### DIFF
--- a/player/drm/css/style.css
+++ b/player/drm/css/style.css
@@ -119,6 +119,10 @@ body .demo-detail .code-example {
     margin-top: 47px;
 }
 
+#bitmovinplayer-video-player-container{
+    border-radius: 0 !important;
+}
+
 .sdk-wrapper-title {
     font-size: 20px;
     line-height: 23px;

--- a/player/drm/css/style.css
+++ b/player/drm/css/style.css
@@ -119,7 +119,7 @@ body .demo-detail .code-example {
     margin-top: 47px;
 }
 
-#bitmovinplayer-video-player-container{
+#bitmovinplayer-video-player-container, #player-container {
     border-radius: 0 !important;
 }
 

--- a/player/drm/css/style.css
+++ b/player/drm/css/style.css
@@ -119,7 +119,7 @@ body .demo-detail .code-example {
     margin-top: 47px;
 }
 
-#bitmovinplayer-video-player-container, #player-container {
+#player-container > * {
     border-radius: 0 !important;
 }
 


### PR DESCRIPTION
# Problem 
The DRM demo does not render the video after the content has been started for a Playready stream. This has been observed on Chromium Edge running on Windows. 
The root cause for this issue is due to the border-radius manipulating the video element. Playready streams do not allow manipulation of the video element and they directly stop rendering due to this styling change.

# Fix
Here I force the border-radius from the container and video element to always have no border-radius to allow video to be rendered. 