### PR TITLE
Update LA_URL due to error 500 on current url

### DIFF
--- a/player/drm/demo.js
+++ b/player/drm/demo.js
@@ -11,7 +11,7 @@ var source = {
   smooth: 'https://test.playready.microsoft.com/smoothstreaming/SSWSS720H264/SuperSpeedway_720.ism/manifest',
   drm: {
     widevine: {
-      LA_URL: 'https://widevine-proxy.appspot.com/proxy'
+      LA_URL: 'https://cwip-shaka-proxy.appspot.com/no_auth'
     },
     playready: {
       LA_URL: 'https://playready.directtaps.net/pr/svc/rightsmanager.asmx?PlayRight=1&ContentKey=EAtsIJQPd5pFiRUrV9Layw=='

--- a/player/drm/js/script.js
+++ b/player/drm/js/script.js
@@ -12,7 +12,7 @@
     'smooth': 'https://test.playready.microsoft.com/smoothstreaming/SSWSS720H264/SuperSpeedway_720.ism/manifest',
     'drm': {
       'widevine': {
-        'LA_URL': 'https://widevine-proxy.appspot.com/proxy'
+        'LA_URL': 'https://cwip-shaka-proxy.appspot.com/no_auth'
       },
       'playready': {
         'LA_URL': 'https://playready.directtaps.net/pr/svc/rightsmanager.asmx?PlayRight=1&ContentKey=EAtsIJQPd5pFiRUrV9Layw=='


### PR DESCRIPTION
https://widevine-proxy.appspot.com/proxy gives error 500 / fails
https://cwip-shaka-proxy.appspot.com/no_auth works as intended

I found the above new url was being used here:
https://shaka-player-demo.appspot.com/demo/#audiolang=en-NZ;textlang=en-NZ;uilang=en-NZ;asset=https://storage.googleapis.com/shaka-demo-assets/sintel-widevine/dash.mpd;panel=ALL_CONTENT;panelData=drm:WIDEVINE;build=uncompiled

fixes: https://github.com/bitmovin/demos/issues/57