### PR TITLE
Re-enable VR demo on iOS devices

### DIFF
--- a/player/vr-360/css/style.css
+++ b/player/vr-360/css/style.css
@@ -10,23 +10,6 @@ div.input-hint {
     display: none;
 }
 
-#player.is-unsupported {
-    height: 100%;
-    margin: 15px 0;
-}
-
-#player.is-unsupported #player-container {
-    min-height: 150px;
-    min-width: 260px;
-    display: flex;
-    align-items: center;
-}
-
-.message-not-supported {
-    padding: 0 60px;
-    font-size: 18px;
-}
-
 @media (min-width: 991px) {
     div.input-hint {
         margin-top: 30px;
@@ -98,11 +81,4 @@ body .demo-detail .description {
 body:not(.fullscreen) :not(.no-frame).phone-frame::before {
     top: 0;
     left: 0;
-}
-
-@media (max-width: 767px) {
-    .message-not-supported {
-        border: 1px solid #dee2e6;
-        padding: 20px;
-    }
 }

--- a/player/vr-360/js/script.js
+++ b/player/vr-360/js/script.js
@@ -1,55 +1,29 @@
-function isIOS() {
-  return /iPad|iPhone|iPod/.test(navigator.platform);
+var conf = {
+  key: '29ba4a30-8b5e-4336-a7dd-c94ff3b25f30',
+  analytics: {
+    key: '45adcf9b-8f7c-4e28-91c5-50ba3d442cd4',
+    videoId: 'vr-360'
+  },
+  style: {
+    aspectratio: '2:1'
+  },
+  playback: {
+    muted: true
+  }
 };
 
-if (isIOS()) {
-  showNotSupportedMessage();
-} else {
-  setupPlayer();
-}
+var source = {
+  dash: 'https://bitmovin-a.akamaihd.net/content/playhouse-vr/mpds/105560.mpd',
+  hls: 'https://bitmovin.com/player-content/playhouse-vr/m3u8s/105560.m3u8',
+  progressive: 'https://bitmovin.com/player-content/playhouse-vr/progressive.mp4',
+  poster: 'https://bitmovin-a.akamaihd.net/content/playhouse-vr/poster.jpg',
+  vr: {
+    startupMode: '2d',
+    startPosition: 180
+  }
+};
 
-function showNotSupportedMessage() {
-  var message = 'This demo is not currently available on iOS as we’re working to enhance this VR/360 demo. Please get in touch if you’d like to learn more.';
+var playerContainer = document.getElementById('player-container');
+var player = new bitmovin.player.Player(playerContainer, conf);
 
-  var container = document.getElementById('player-container');
-  var player = document.getElementById('player');
-  var messageContainer = document.createElement('div');
-
-  messageContainer.setAttribute('class', 'message-not-supported')
-  messageContainer.textContent = message
-
-  container.append(messageContainer);
-  player.classList.add('is-unsupported');
-}
-
-function setupPlayer() {
-  var conf = {
-    key: '29ba4a30-8b5e-4336-a7dd-c94ff3b25f30',
-    analytics: {
-      key: '45adcf9b-8f7c-4e28-91c5-50ba3d442cd4',
-      videoId: 'vr-360'
-    },
-    style: {
-      aspectratio: '2:1'
-    },
-    playback: {
-      muted: true
-    }
-  };
-  
-  var source = {
-    dash: 'https://bitmovin-a.akamaihd.net/content/playhouse-vr/mpds/105560.mpd',
-    hls: 'https://bitmovin.com/player-content/playhouse-vr/m3u8s/105560.m3u8',
-    progressive: 'https://bitmovin.com/player-content/playhouse-vr/progressive.mp4',
-    poster: 'https://bitmovin-a.akamaihd.net/content/playhouse-vr/poster.jpg',
-    vr: {
-      startupMode: '2d',
-      startPosition: 180
-    }
-  };
-  
-  var playerContainer = document.getElementById('player-container');
-  var player = new bitmovin.player.Player(playerContainer, conf);
-  
-  player.load(source);
-}
+player.load(source);


### PR DESCRIPTION
Re-enable the VR demo on iOS devices after it has been disabled in https://github.com/bitmovin/demos/pull/48. The underlying issue that broke VR playback will be fixed in Player v8.70.0.

**This branch shall not be merged before v8.70.0 was released.**