### PR TITLE
Update VR demo source

### DIFF
--- a/player/vr-360/js/script.js
+++ b/player/vr-360/js/script.js
@@ -14,8 +14,8 @@ var conf = {
 
 var source = {
   dash: 'https://bitmovin-a.akamaihd.net/content/playhouse-vr/mpds/105560.mpd',
-  hls: 'https://bitmovin.com/player-content/playhouse-vr/m3u8s/105560.m3u8',
-  progressive: 'https://bitmovin.com/player-content/playhouse-vr/progressive.mp4',
+  hls: 'https://bitmovin-a.akamaihd.net/content/playhouse-vr/m3u8s/105560.m3u8',
+  progressive: 'https://bitmovin-a.akamaihd.net/content/playhouse-vr/progressive.mp4',
   poster: 'https://bitmovin-a.akamaihd.net/content/playhouse-vr/poster.jpg',
   vr: {
     startupMode: '2d',


### PR DESCRIPTION
The VR demo was re-enabled for iOS in https://github.com/bitmovin/demos/pull/59. However, the used HLS and progressive sources are no longer available and either return a `404` or redirect to an error page. This PR therefore replaces those non-working URLs with working ones.

For reference: there was a restriction on iOS < 11.1 that required VR content to be served from the same domain that the player was served from. This restriction no longer exists, so it is no longer necessary to serve the HLS and progressive sources from `https://bitmovin.com`.