### PR TITLE
Fix Ad Scheduling Demo

### DIFF
--- a/player/ad-scheduling/index.html
+++ b/player/ad-scheduling/index.html
@@ -34,7 +34,6 @@
                 <option selected="selected" value="vast">VAST</option>
                 <option value="vpaid">VPAID</option>
                 <option value="vmap">VMAP</option>
-                <option value="ima">IMA</option>
             </select>
         </div>
         <div class="col-sm-6 mb-3">
@@ -83,4 +82,4 @@
         </div>
     </div>
 </div>
-  
+

--- a/player/ad-scheduling/js/script.js
+++ b/player/ad-scheduling/js/script.js
@@ -51,8 +51,7 @@ function loadConfig() {
           break;
         }
         case 'vpaid': {
-          // same as VAST
-          manifestUrl = '//pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/32573358/skippable_ad_unit&impl=s&gdfp_req=1&env=vp&output=xml_vast2&unviewed_position_start=1&url=http%3A%2F%2Freleasetest.dash-player.com%2Fads%2F&description_url=[description_url]&correlator=[random]';
+          manifestUrl = '//pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/124319096/external/single_ad_samples&ciu_szs=300x250&impl=s&gdfp_req=1&env=vp&output=vast&unviewed_position_start=1&cust_params=deployment%3Ddevsite%26sample_ct%3Dlinearvpaid2js&correlator=[random]';
           break;
         }
         default: {

--- a/player/ad-scheduling/js/script.js
+++ b/player/ad-scheduling/js/script.js
@@ -46,10 +46,6 @@ function loadConfig() {
     var manifestUrl = document.getElementById('ad-server-url').value;
     if (!manifestUrl) {
       switch (adType) {
-        case 'ima': {
-          manifestUrl = '//pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/124319096/external/single_ad_samples&ciu_szs=300x250&impl=s&gdfp_req=1&env=vp&output=vast&unviewed_position_start=1&cust_params=deployment%3Ddevsite%26sample_ct%3Dlinear&correlator=[random]';
-          break;
-        }
         case 'vmap': {
           manifestUrl = '//pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/124319096/external/ad_rule_samples&ciu_szs=300x250&ad_rule=1&impl=s&gdfp_req=1&env=vp&output=vmap&unviewed_position_start=1&cust_params=deployment%3Ddevsite%26sample_ar%3Dpreonly&cmsid=496&vid=short_onecue&correlator=[random]';
           break;
@@ -61,15 +57,12 @@ function loadConfig() {
         }
         default: {
           // reset to VAST
-          manifestUrl = '//pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/32573358/skippable_ad_unit&impl=s&gdfp_req=1&env=vp&output=xml_vast2&unviewed_position_start=1&url=http%3A%2F%2Freleasetest.dash-player.com%2Fads%2F&description_url=[description_url]&correlator=[random]';
+          manifestUrl = '//pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/124319096/external/single_ad_samples&ciu_szs=300x250&impl=s&gdfp_req=1&env=vp&output=vast&unviewed_position_start=1&cust_params=deployment%3Ddevsite%26sample_ct%3Dlinear&correlator=[random]';
           document.getElementById('adType').value = 'vast';
         }
       }
     }
-    // vmap is handled as ima tag
-    if (adType === 'vmap') {
-      adType = 'ima';
-    }
+
     player.ads.schedule({
       tag: {
         url: manifestUrl,

--- a/player/ad-scheduling/js/script.js
+++ b/player/ad-scheduling/js/script.js
@@ -10,7 +10,11 @@ var conf = {
   },
   events: {
     aderror: function (err) {
-      document.querySelector('#ad-error').innerHTML = 'Ad-Error:' + err.message;
+      var errorMessage = 'Ad-Error: ' + err.message;
+      if (err.data && err.data.message) {
+        errorMessage = errorMessage + ': ' + err.data.message;
+      }
+      document.querySelector('#ad-error').innerHTML = errorMessage;
     },
     warning: function (err) {
       document.querySelector('#ad-warning').innerHTML = err.message;

--- a/player/ad-scheduling/js/script.js
+++ b/player/ad-scheduling/js/script.js
@@ -41,6 +41,8 @@ function resetAdError() {
 function loadConfig() {
   resetAdError();
   var adType = document.getElementById('adType').value || 'vast';
+  var adTagType = adType;
+
   var schedule = document.getElementById('schedule-list').value;
   if (schedule) {
     var manifestUrl = document.getElementById('ad-server-url').value;
@@ -48,15 +50,18 @@ function loadConfig() {
       switch (adType) {
         case 'vmap': {
           manifestUrl = '//pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/124319096/external/ad_rule_samples&ciu_szs=300x250&ad_rule=1&impl=s&gdfp_req=1&env=vp&output=vmap&unviewed_position_start=1&cust_params=deployment%3Ddevsite%26sample_ar%3Dpreonly&cmsid=496&vid=short_onecue&correlator=[random]';
+          adTagType = 'vmap';
           break;
         }
         case 'vpaid': {
           manifestUrl = '//pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/124319096/external/single_ad_samples&ciu_szs=300x250&impl=s&gdfp_req=1&env=vp&output=vast&unviewed_position_start=1&cust_params=deployment%3Ddevsite%26sample_ct%3Dlinearvpaid2js&correlator=[random]';
+          adTagType = 'vast';
           break;
         }
         default: {
           // reset to VAST
           manifestUrl = '//pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/124319096/external/single_ad_samples&ciu_szs=300x250&impl=s&gdfp_req=1&env=vp&output=vast&unviewed_position_start=1&cust_params=deployment%3Ddevsite%26sample_ct%3Dlinear&correlator=[random]';
+          adTagType = 'vast';
           document.getElementById('adType').value = 'vast';
         }
       }
@@ -65,7 +70,7 @@ function loadConfig() {
     player.ads.schedule({
       tag: {
         url: manifestUrl,
-        type: adType
+        type: adTagType
       },
       id: 'Ad',
       position: document.getElementById('schedule-list').value


### PR DESCRIPTION
This aligns the ad scheduling demo with the ad tag types that are currently supported in our player: https://bitmovin.com/docs/player/api-reference/web/web-sdk-api-reference-v8#/player/web/8/docs/enums/advertising.adtagtype.html

Changes:
- Remove legacy ad type "IMA"
- Exchange asset for VPAID, as it would always return an empty tag
- Pass the correct ad tag type to the player (`vmap` for vmap, `vast` for vpaid)