### PR TITLE
Fix ad scheduling on "Stream Test" demo

### DIFF
--- a/player/stream-test/js/script.js
+++ b/player/stream-test/js/script.js
@@ -468,7 +468,7 @@ function createAdBox(number) {
   $('<div class="demo-input-box ad-box" id="ad-box-' + number + '"> \
   <div class="demo-item-header"> \
       <div>AD' + number + ' </div> \
-      <button id="delete-ad' + number + '" class="btn btn-outline-primary active demo-button" type="delete-ad" onclick=hideAd("ad-box-' + number + '")>Delete</button> \
+      <button id="delete-ad' + number + '" class="btn btn-outline-primary active demo-button" type="delete-ad">Delete</button> \
   </div> \
   <div class="demo-stream-type-input"> \
       <div class="type-header">AD Type</div> \
@@ -509,7 +509,11 @@ function createAdBox(number) {
         setDefaultInput(adRadioButton, 'ad' + number + '-input', defaultAdUrl);
       })
     }(i))
-  };
+  }
+
+  document.getElementById('delete-ad' + number).addEventListener('click', function() {
+    hideAd('ad-box-' + number);
+  });
 
   if (adArray && adArray.length === 3) {
     scheduleAdButton.classList.add('disabled');

--- a/player/stream-test/js/script.js
+++ b/player/stream-test/js/script.js
@@ -77,9 +77,9 @@ var drmSource = {
 };
 
 var defaultAdUrl = {
-  vast: 'https://pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/32573358/skippable_ad_unit&impl=s&gdfp_req=1&env=vp&output=xml_vast2&unviewed_position_start=1&url=http%3A%2F%2Freleasetest.dash-player.com%2Fads%2F&description_url=[description_url]&correlator=[random]',
-  vpaid: 'https://pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/32573358/skippable_ad_unit&impl=s&gdfp_req=1&env=vp&output=xml_vast2&unviewed_position_start=1&url=http%3A%2F%2Freleasetest.dash-player.com%2Fads%2F&description_url=[description_url]&correlator=[random]',
-  vmap: 'https://pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/124319096/external/ad_rule_samples&ciu_szs=300x250&ad_rule=1&impl=s&gdfp_req=1&env=vp&output=vmap&unviewed_position_start=1&cust_params=deployment%3Ddevsite%26sample_ar%3Dpreonly&cmsid=496&vid=short_onecue&correlator=[random]',
+  vast: '//pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/124319096/external/single_ad_samples&ciu_szs=300x250&impl=s&gdfp_req=1&env=vp&output=vast&unviewed_position_start=1&cust_params=deployment%3Ddevsite%26sample_ct%3Dlinear&correlator=[random]',
+  vpaid: '//pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/124319096/external/single_ad_samples&ciu_szs=300x250&impl=s&gdfp_req=1&env=vp&output=vast&unviewed_position_start=1&cust_params=deployment%3Ddevsite%26sample_ct%3Dlinearvpaid2js&correlator=[random]',
+  vmap: '//pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/124319096/external/ad_rule_samples&ciu_szs=300x250&ad_rule=1&impl=s&gdfp_req=1&env=vp&output=vmap&unviewed_position_start=1&cust_params=deployment%3Ddevsite%26sample_ar%3Dpreonly&cmsid=496&vid=short_onecue&correlator=[random]',
 };
 
 var initialTimestamp, bufferChart, bitrateChart;

--- a/player/stream-test/js/script.js
+++ b/player/stream-test/js/script.js
@@ -80,7 +80,6 @@ var defaultAdUrl = {
   vast: 'https://pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/32573358/skippable_ad_unit&impl=s&gdfp_req=1&env=vp&output=xml_vast2&unviewed_position_start=1&url=http%3A%2F%2Freleasetest.dash-player.com%2Fads%2F&description_url=[description_url]&correlator=[random]',
   vpaid: 'https://pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/32573358/skippable_ad_unit&impl=s&gdfp_req=1&env=vp&output=xml_vast2&unviewed_position_start=1&url=http%3A%2F%2Freleasetest.dash-player.com%2Fads%2F&description_url=[description_url]&correlator=[random]',
   vmap: 'https://pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/124319096/external/ad_rule_samples&ciu_szs=300x250&ad_rule=1&impl=s&gdfp_req=1&env=vp&output=vmap&unviewed_position_start=1&cust_params=deployment%3Ddevsite%26sample_ar%3Dpreonly&cmsid=496&vid=short_onecue&correlator=[random]',
-  ima: 'https://pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/124319096/external/single_ad_samples&ciu_szs=300x250&impl=s&gdfp_req=1&env=vp&output=vast&unviewed_position_start=1&cust_params=deployment%3Ddevsite%26sample_ct%3Dlinear&correlator=[random]'
 };
 
 var initialTimestamp, bufferChart, bitrateChart;
@@ -480,9 +479,6 @@ function createAdBox(number) {
       </div> \
       <div class="input-type"> \
         <label><input id="ad' + number + '-type" type="radio" name="ad' + number + '-type" value="vmap"> VMAP</label> \
-      </div> \
-      <div class="input-type"> \
-        <label><input id="ad' + number + '-type" type="radio" name="ad' + number +'-type" value="ima"> IMA</label> \
       </div> \
   </div> \
   <div class="demo-stream-type-input"> \

--- a/player/stream-test/js/script.js
+++ b/player/stream-test/js/script.js
@@ -733,6 +733,11 @@ function setPlayerEvents(player) {
     updateCharts(player);
   });
 
+  player.on(bitmovin.player.PlayerEvent.AdError, function (data) {
+    log("On Ad Error: " + JSON.stringify(data));
+    updateCharts(player);
+  });
+
   player.on(bitmovin.player.PlayerEvent.Seek, function (data) {
     log("On Seek Started: " + JSON.stringify(data));
     updateCharts(player);

--- a/player/stream-test/js/script.js
+++ b/player/stream-test/js/script.js
@@ -306,13 +306,13 @@ function createAdConfig() {
 
     if (adBox) {
       var adManifestUrl = document.getElementById('ad' + i + '-input').value;
-      var adType = document.querySelector('[name="ad' + i + '-type"]:checked').value;
+      var adTagType = document.querySelector('[name="ad' + i + '-type"]:checked').getAttribute('data-tag-type');
       var adPosition = document.querySelector('[name="ad' + i + '-position"]:checked').value;
 
       player.ads.schedule({
         tag: {
           url: adManifestUrl,
-          type: adType
+          type: adTagType
         },
         id: 'Ad$' + i,
         position: adPosition
@@ -472,13 +472,13 @@ function createAdBox(number) {
   <div class="demo-stream-type-input"> \
       <div class="type-header">AD Type</div> \
       <div class="input-type"> \
-        <label><input id="ad' + number + '-type" type="radio" name="ad' + number + '-type" value="vast" checked> VAST</label> \
+        <label><input id="ad' + number + '-type" type="radio" name="ad' + number + '-type" value="vast" data-tag-type="vast" checked> VAST</label> \
       </div> \
       <div class="input-type"> \
-        <label><input id="ad' + number + '-type" type="radio" name="ad' + number + '-type" value="vpaid"> VPAID</label> \
+        <label><input id="ad' + number + '-type" type="radio" name="ad' + number + '-type" value="vpaid" data-tag-type="vast"> VPAID</label> \
       </div> \
       <div class="input-type"> \
-        <label><input id="ad' + number + '-type" type="radio" name="ad' + number + '-type" value="vmap"> VMAP</label> \
+        <label><input id="ad' + number + '-type" type="radio" name="ad' + number + '-type" value="vmap" data-tag-type="vmap"> VMAP</label> \
       </div> \
   </div> \
   <div class="demo-stream-type-input"> \


### PR DESCRIPTION
This fixes ad scheduling on the [stream test demo](https://bitmovin.com/demos/stream-test), which does not work as expected atm:
- Some ads to not work because the manifest requests return empty VAST
- The "Delete"  button to remove an ad does not work
- "IMA" is not a valid ad tag type anymore

Changes in this PR:
- Fix the "Delete" button by assigning an event listener instead of using the `onclick` attribute
- Align the ad tag types with the ones that are currently supported in our player: https://bitmovin.com/docs/player/api-reference/web/web-sdk-api-reference-v8#/player/web/8/docs/enums/advertising.adtagtype.html
- Replace ad manifest URLs with working ones
- Pass the correct ad tag type to the player (specifically, `vast` for vpaid - since [vpaid is deprecated](https://bitmovin.com/docs/player/api-reference/web/web-sdk-api-reference-v8#/player/web/8/docs/enums/advertising.adtagtype.html#vpaid))
- Show Ad Errors in the Event Log on the page

The changes here are similar to the ones done on the "Ad Scheduling" demo: https://github.com/bitmovin/demos/pull/72