### PR TITLE
Update demo priorities and android links

### DIFF
--- a/analytics/analytics-bitrate-ladder-validator/info.json
+++ b/analytics/analytics-bitrate-ladder-validator/info.json
@@ -31,5 +31,6 @@
     "testing",
     "QOE"
   ],
-  "hide_github_link": true
+  "hide_github_link": true,
+  "priority": 1020
 }

--- a/player/drm/index.html
+++ b/player/drm/index.html
@@ -109,7 +109,7 @@
                     </div>
                 </a>
             </div>
-            <a target="_blank" class="sdk-item-url" href="https://play.google.com/store/apps/details?id=com.bitmovin.playerdemo">
+            <a target="_blank" class="sdk-item-url" href="https://play.google.com/store/apps/details?id=com.bitmovin.demo.player">
                 <img src="https://bitmovin-a.akamaihd.net/webpages/demo-fw/stream-test/GooglePlay.svg" />
             </a>
         </div>

--- a/player/drm/info.json
+++ b/player/drm/info.json
@@ -22,5 +22,5 @@
     "widevine",
     "playready"
   ],
-  "priority": 880
+  "priority": 1040
 }

--- a/player/native-sdks/index.html
+++ b/player/native-sdks/index.html
@@ -42,7 +42,7 @@
                 </a>
             </div>
             <div class="col-6">
-                <a href="https://play.google.com/store/apps/details?id=com.bitmovin.playerdemo" target="_blank"
+                <a href="https://play.google.com/store/apps/details?id=com.bitmovin.demo.player" target="_blank"
                    title="Bitmovin on Google Play" class="d-flex justify-content-start align-center">
                     <img src="//bitmovin-a.akamaihd.net/webpages/demo-fw/native-sdks/google-play-badge.svg"
                          alt="Bitmovin on Google Play">

--- a/player/stream-test/index.html
+++ b/player/stream-test/index.html
@@ -124,7 +124,7 @@
                     </div>
                 </a>
             </div>
-            <a target="_blank" class="sdk-item-url" href="https://play.google.com/store/apps/details?id=com.bitmovin.playerdemo">
+            <a target="_blank" class="sdk-item-url" href="https://play.google.com/store/apps/details?id=com.bitmovin.demo.player">
                 <img src="https://bitmovin-a.akamaihd.net/webpages/demo-fw/stream-test/GooglePlay.svg" />
             </a>
         </div>

--- a/player/stream-test/info.json
+++ b/player/stream-test/info.json
@@ -22,5 +22,5 @@
     "test",
     "player"
   ],
-  "priority": 900
+  "priority": 1060
 }


### PR DESCRIPTION
This PR updates URLs leading to the Android demo-app in the corresponding demos and updates priority of popular demos so they appear on top of the demos-overview.