### PR TITLE
Fix Playready DRM playback in stream-test demo

### DIFF
--- a/player/stream-test/css/style.css
+++ b/player/stream-test/css/style.css
@@ -113,6 +113,10 @@ body:not(.fullscreen) :not(.no-frame).notebook-frame::before {
     margin-top: 47px;
 }
 
+#player, #player > * {
+  border-radius: 0 !important;
+}
+
 .sdk-wrapper-title {
     font-size: 20px;
     line-height: 23px;


### PR DESCRIPTION
Problem:
Playready DRM streams were not working on the stream-test demo page in (Chromium-based) Edge due to the CSS border-radius above the video and how the Playready video rendering pipeline workds.

Resolution:
Remove CSS border-radius on elements above the video.