### PR TITLE
Remove OMSDK lib files

### DIFF
--- a/player/ad-event-verification-omsdk/index.html
+++ b/player/ad-event-verification-omsdk/index.html
@@ -1,5 +1,3 @@
-<script src="https://cdn.bitmovin.com/content/player-web/lib/omsdk/omweb-js-1.3.25/Service/omweb-v1.js" type="text/javascript"></script>
-<script src="https://cdn.bitmovin.com/content/player-web/lib/omsdk/omweb-js-1.3.25/Session-Client/omid-session-client-v1.js" type="text/javascript"></script>
 <script src="https://cdn.bitmovin.com/player/web/8/bitmovinplayer.js" type="text/javascript"></script>
 <script src="https://cdn.bitmovin.com/player/web/8/bitmovinplayer-ui.js" type="text/javascript"></script>
 <script src="https://cdn.bitmovin.com/analytics/web/beta/2/bitmovinanalytics.min.js" type="text/javascript"></script>

--- a/player/ad-event-verification-omsdk/page.html
+++ b/player/ad-event-verification-omsdk/page.html
@@ -1,7 +1,3 @@
-<!-- Open Measurement SDK Scripts -->
-<script type="text/javascript" src="./omsdk/Service/omweb-v1.js"></script>
-<script type="text/javascript" src="./omsdk/Session-Client/omid-session-client-v1.js"></script>
-
 <!-- Bitmovin Modular Player Scripts -->
 <script type="text/javascript" src="https://cdn.bitmovin.com/player/web/8/modules/bitmovinplayer-core.js"></script>
 <script type="text/javascript" src="https://cdn.bitmovin.com/player/web/8/modules/bitmovinplayer-engine-bitmovin.js"></script>


### PR DESCRIPTION
As of version `8.81.0` the OMSDK lib files are part of the player bundle so we can remove these.
https://bitmovin.com/docs/player/releases/web/web-8-81-0