### PR TITLE
Fix button colors in UI styling demo

### DIFF
--- a/player/player-ui-styling/index.html
+++ b/player/player-ui-styling/index.html
@@ -35,12 +35,12 @@
                     </button>
                 </div>
                 <div class="col-md-12">
-                    <button class="ui-button btn btn-warning" id="bigseek" type="button">
+                    <button class="ui-button btn btn-secondary" id="bigseek" type="button">
                         Toggle Big Seek Bar
                     </button>
                 </div>
                 <div class="col-md-12">
-                    <button class="ui-button btn btn-secondary" id="color1" type="button">
+                    <button class="ui-button btn btn-warning" id="color1" type="button">
                         Orange Seek Bar
                     </button>
                 </div>


### PR DESCRIPTION
Align the button colors with what the buttons do.

Makes the `Orange Seek Bar` button orange/yellow, and the `Toggle Big Seek Bar` button gray.

Currently, it's the other way around, which is annoying :D https://bitmovin.com/demos/player-ui-styling