### PR TITLE
Fix big seek bar toggle in UI styling demo

### DIFF
--- a/player/player-ui-styling/css/style.css
+++ b/player/player-ui-styling/css/style.css
@@ -52,6 +52,10 @@ a {
 /*background-color: #ff1237;*/
 /*}*/
 
+.bmpui-seekbar.bigseek > * {
+    font-size: 3em;
+}
+
 .bmpui-seekbar-backdrop.orange {
     background-color: #ff931e !important;
 }

--- a/player/player-ui-styling/js/script.js
+++ b/player/player-ui-styling/js/script.js
@@ -16,7 +16,7 @@ var source = {
   poster: 'https://bitmovin-a.akamaihd.net/content/sintel/poster.png'
 };
 
-var currentUiManager, isBigSeekbar = false, isSmallscreen = false;
+var currentUiManager, isSmallscreen = false;
 
 var playerContainer = document.getElementById('player-container');
 var player = new bitmovin.player.Player(playerContainer, conf);
@@ -43,8 +43,6 @@ document.getElementById('watermark').addEventListener('click', function() {
 
 
 document.getElementById('bigseek').addEventListener('click', function() {
-  isBigSeekbar = !isBigSeekbar;
-
   var seekbar = $('.bmpui-seekbar')[0];
   seekbar.classList.toggle('bigseek');
 });

--- a/player/player-ui-styling/js/script.js
+++ b/player/player-ui-styling/js/script.js
@@ -43,8 +43,10 @@ document.getElementById('watermark').addEventListener('click', function() {
 
 
 document.getElementById('bigseek').addEventListener('click', function() {
-  $('.bmpui-ui-seekbar').css('font-size', isBigSeekbar ? '1em' : '3em');
   isBigSeekbar = !isBigSeekbar;
+
+  var seekbar = $('.bmpui-seekbar')[0];
+  seekbar.classList.toggle('bigseek');
 });
 
 document.getElementById('color2').addEventListener('click', function() {


### PR DESCRIPTION
The `Toggle big seek bar` functionality did not work as CSS for the affected elements got overridden by global CSS.

This PR adds a more specific CSS selector. Also, it moves the styles for the big seek bar to the `.css` file and clicking the button now toggles a class, instead of changing inline CSS.