### PR TITLE
Updated mutli codec demo and FA fonts

### DIFF
--- a/encoding/multi-codec-streaming/js/demo.js
+++ b/encoding/multi-codec-streaming/js/demo.js
@@ -290,25 +290,33 @@ var getCodecImage = function (selectedCodec) {
   }
 };
 
-var getBrowserImage = function (selectedBrowser) {
+function getBrowserImage(selectedBrowser) {
   switch (selectedBrowser) {
     case BROWSER.CHROME:
-      return '<i class="fa fa-chrome browser-icon" aria-hidden="true"></i>';
+      return '<i class="fa-brands fa-chrome" aria-hidden="true"></i>';
     case BROWSER.EDGE:
-      return '<i class="fa fa-edge browser-icon" aria-hidden="true"></i>';
+      return '<i class="fa-brands fa-edge" aria-hidden="true"></i>';
     case BROWSER.FIREFOX:
-      return '<i class="fa fa-firefox browser-icon" aria-hidden="true"></i>';
+      return '<i class="fa-brands fa-firefox" aria-hidden="true"></i>';
     case BROWSER.IE:
-      return '<i class="fa fa-internet-explorer browser-icon" aria-hidden="true"></i>';
+      return '<i class="fa-brands fa-internet-explorer" aria-hidden="true"></i>';
     case BROWSER.OPERA:
-      return '<i class="fa fa-opera browser-icon" aria-hidden="true"></i>';
+      return '<i class="fa-brands fa-opera" aria-hidden="true"></i>';
     case BROWSER.SAFARI:
-      return '<i class="fa fa-safari browser-icon" aria-hidden="true"></i>';
+      return '<i class="fa-brands fa-safari" aria-hidden="true"></i>';
     case BROWSER.UNKNOWN:
     default:
-      return '<i class="fa fa-question browser-icon" aria-hidden="true"></i>';
+      return '<i class="fa-solid fa-circle-question" aria-hidden="true"></i>';
   }
 };
+
+function isTypeSupported(mimeType)
+{
+  if ('MediaSource' in window && MediaSource.isTypeSupported(mimeType)) {
+    return true;
+  }
+  return false;
+}
 
 function digitToTime(digit) {
   var minutes = Math.floor(digit / 60);
@@ -515,9 +523,12 @@ var multicodec = function () {
   if (browser === BROWSER.CHROME || browser === BROWSER.FIREFOX) {
     selectedCodec = CODEC.VP9;
     source.dash = '//bitmovin-a.akamaihd.net/webpages/demos/content/multi-codec/vp9/stream.mpd';
-  } else if (browser === BROWSER.EDGE) {
+  } else if (browser === BROWSER.EDGE && isTypeSupported('video/mp4; codecs="hvc1"')) {
     selectedCodec = CODEC.H265;
     source.dash = '//bitmovin-a.akamaihd.net/webpages/demos/content/multi-codec/hevc/stream.mpd';
+  } else if (browser === BROWSER.EDGE && !isTypeSupported('video/mp4; codecs="hvc1"')) {
+    selectedCodec = CODEC.VP9;
+    source.dash = '//bitmovin-a.akamaihd.net/webpages/demos/content/multi-codec/vp9/stream.mpd';
   } else if (browser === BROWSER.SAFARI) {
     selectedCodec = CODEC.H265;
     source.hls = '//bitmovin-a.akamaihd.net/webpages/demos/content/multi-codec/hevc/stream_fmp4.m3u8';

--- a/player/drm/index.html
+++ b/player/drm/index.html
@@ -89,7 +89,7 @@
                 <div style="padding-bottom: 6px;">iOS/tvOS SDK</div>
                 <a target="_blank" onclick="amp.logSDKSourceCodeClicked('drm', 'ios')" href="https://github.com/bitmovin/bitmovin-player-ios-samples">
                     <div style="height: 28px;" class="btn btn-sm btn-outline-dark">
-                        <i class="fa fa-lg fa-github"></i>
+                        <i class="fa-brands fa-github"></i>
                         <span class="pl-1">Check out the SDK</span>
                     </div>
                 </a>
@@ -104,7 +104,7 @@
                 <div style="padding-bottom: 6px;">Android SDK</div>
                 <a target="_blank" onclick="amp.logSDKSourceCodeClicked('drm', 'android')" href="https://github.com/bitmovin/bitmovin-player-android-samples">
                     <div style="height: 28px;" class="btn btn-sm btn-outline-dark">
-                        <i class="fa fa-lg fa-github"></i>
+                        <i class="fa-brands fa-github"></i>
                         <span class="pl-1">Check out the SDK</span>
                     </div>
                 </a>

--- a/player/drm/js/script.js
+++ b/player/drm/js/script.js
@@ -168,20 +168,20 @@
   function getBrowserImage(selectedBrowser) {
     switch (selectedBrowser) {
       case BROWSER.CHROME:
-        return '<i class="fa fa-chrome browser-icon" aria-hidden="true"></i>';
+        return '<i class="fa-brands fa-chrome" aria-hidden="true"></i>';
       case BROWSER.EDGE:
-        return '<i class="fa fa-edge browser-icon" aria-hidden="true"></i>';
+        return '<i class="fa-brands fa-edge" aria-hidden="true"></i>';
       case BROWSER.FIREFOX:
-        return '<i class="fa fa-firefox browser-icon" aria-hidden="true"></i>';
+        return '<i class="fa-brands fa-firefox" aria-hidden="true"></i>';
       case BROWSER.IE:
-        return '<i class="fa fa-internet-explorer browser-icon" aria-hidden="true"></i>';
+        return '<i class="fa-brands fa-internet-explorer" aria-hidden="true"></i>';
       case BROWSER.OPERA:
-        return '<i class="fa fa-opera browser-icon" aria-hidden="true"></i>';
+        return '<i class="fa-brands fa-opera" aria-hidden="true"></i>';
       case BROWSER.SAFARI:
-        return '<i class="fa fa-safari browser-icon" aria-hidden="true"></i>';
+        return '<i class="fa-brands fa-safari" aria-hidden="true"></i>';
       case BROWSER.UNKNOWN:
       default:
-        return '<i class="fa fa-question browser-icon" aria-hidden="true"></i>';
+        return '<i class="fa-solid fa-circle-question" aria-hidden="true"></i>';
     }
   }
 

--- a/player/stream-test/index.html
+++ b/player/stream-test/index.html
@@ -104,7 +104,7 @@
                 <div style="padding-bottom: 6px;">iOS/tvOS SDK</div>
                 <a target="_blank" onclick="amp.logSDKSourceCodeClicked('stream-test', 'ios')" href="https://github.com/bitmovin/bitmovin-player-ios-samples">
                     <div style="height: 28px;" class="btn btn-sm btn-outline-dark">
-                        <i class="fa fa-lg fa-github"></i>
+                        <i class="fa-brands fa-github"></i>
                         <span class="pl-1">Check out the SDK</span>
                     </div>
                 </a>
@@ -119,7 +119,7 @@
                 <div style="padding-bottom: 6px;">Android SDK</div>
                 <a target="_blank" onclick="amp.logSDKSourceCodeClicked('stream-test', 'android')" href="https://github.com/bitmovin/bitmovin-player-android-samples">
                     <div style="height: 28px;" class="btn btn-sm btn-outline-dark">
-                        <i class="fa fa-lg fa-github"></i>
+                        <i class="fa-brands fa-github"></i>
                         <span class="pl-1">Check out the SDK</span>
                     </div>
                 </a>


### PR DESCRIPTION
Based on request from [SOL-2888](https://bitmovin.atlassian.net/browse/SOL-2888).
2 changes made on demos:
1. Multi codec demo: added logic to determine the Supported MediaType in EDGE, as right now it was hardcoded causing that it showed: using HEVC in the demo page even for EDGE for Mac (which does not support HEVC)
2. Updated Font Awesome styles to reflect latest version of FA and being able to obtain the newest logo for Microsoft Age.

The url to the CDN of Font-Awesome was changed on the Main project (outside demo folder) so is part of a separate PR