### PR TITLE
Replace license server url to fix CORS errors

### DIFF
--- a/player/drm/demo.js
+++ b/player/drm/demo.js
@@ -11,7 +11,7 @@ var source = {
   smooth: 'https://test.playready.microsoft.com/smoothstreaming/SSWSS720H264/SuperSpeedway_720.ism/manifest',
   drm: {
     widevine: {
-      LA_URL: 'https://widevine-proxy.appspot.com/proxy'
+      LA_URL: 'https://cwip-shaka-proxy.appspot.com/no_auth'
     },
     playready: {
       LA_URL: 'https://playready.directtaps.net/pr/svc/rightsmanager.asmx?PlayRight=1&ContentKey=EAtsIJQPd5pFiRUrV9Layw=='

--- a/player/drm/js/script.js
+++ b/player/drm/js/script.js
@@ -12,7 +12,7 @@
     'smooth': 'https://test.playready.microsoft.com/smoothstreaming/SSWSS720H264/SuperSpeedway_720.ism/manifest',
     'drm': {
       'widevine': {
-        'LA_URL': 'https://widevine-proxy.appspot.com/proxy'
+        'LA_URL': 'https://cwip-shaka-proxy.appspot.com/no_auth'
       },
       'playready': {
         'LA_URL': 'https://playready.directtaps.net/pr/svc/rightsmanager.asmx?PlayRight=1&ContentKey=EAtsIJQPd5pFiRUrV9Layw=='

--- a/player/stream-test/js/script.js
+++ b/player/stream-test/js/script.js
@@ -71,7 +71,7 @@ var drmSource = {
   progressive: '',
   drm: {
     none: '',
-    widevine: 'https://widevine-proxy.appspot.com/proxy',
+    widevine: 'https://cwip-shaka-proxy.appspot.com/no_auth',
     playready: 'https://playready.directtaps.net/pr/svc/rightsmanager.asmx?PlayRight=1&ContentKey=EAtsIJQPd5pFiRUrV9Layw=='
   }
 };


### PR DESCRIPTION
The currently used License Server was missing CORS headers, leading to failing license requests. Using a different license server fixes this issue.