### PR TITLE
fix(EN-11519): improve AV1 break-even calculator

### DIFF
--- a/encoding/av1-break-even-calculator/index.html
+++ b/encoding/av1-break-even-calculator/index.html
@@ -163,7 +163,10 @@
   <ol>
     <li class="mb-2" style="font-size: 12px;">
       <span id="formulaFootnote">
-        Simplified formula break-even point: ( [AV1 encoding cost] + [AV1 ingress cost] ) / ( [H.26X CDN delivery cost] - [AV1 CDN delivery cost] )
+        For the break-even point calculation we calculated the number of views such as:
+        [H.26X encoding cost] + ( [views] * [H.26X CDN delivery cost] )
+        is equal to
+        [H.26X encoding cost] + [AV1 encoding cost] + ( [views] * [AV1 CDN delivery cost] )
       </span>
     </li>
   </ol>

--- a/encoding/av1-break-even-calculator/index.html
+++ b/encoding/av1-break-even-calculator/index.html
@@ -116,9 +116,6 @@
 <div class="container">
   <div class="row">
     <table class="table">
-      <!-- <thead>
-        <th colspan="3">Multipliers</th>
-      </thead> -->
       <tbody>
         <tr class="table-secondary">
           <th colspan="3">Resolution factors</th>

--- a/encoding/av1-break-even-calculator/index.html
+++ b/encoding/av1-break-even-calculator/index.html
@@ -129,12 +129,12 @@
           <td>4</td>
         </tr>
         <tr class="table-secondary">
-          <th>PerTitle</th>
-          <th colspan="2">3-Pass</th>
+          <th>3-Pass</th>
+          <th colspan="2"></th>
         </tr>
         <tr>
-          <td>1.1</td>
-          <td colspan="2">2</td>
+          <td>2</td>
+          <td colspan="2"></td>
         </tr>
         <tr class="table-secondary">
           <th>H264</th>
@@ -148,11 +148,13 @@
         </tr>
         <tr class="table-secondary">
           <th>AV1 efficiency improvement over H.264</th>
-          <th colspan="2">AV1 efficiency improvement over H.265</th>
+          <th>AV1 efficiency improvement over H.265</th>
+          <th></th>
         </tr>
         <tr>
           <td>50%</td>
-          <td colspan="2">30%</td>
+          <td>30%</td>
+          <td></td>
         </tr>
       </tbody>
     </table>

--- a/encoding/av1-break-even-calculator/index.html
+++ b/encoding/av1-break-even-calculator/index.html
@@ -116,11 +116,14 @@
 <div class="container">
   <div class="row">
     <table class="table">
-      <thead>
+      <!-- <thead>
         <th colspan="3">Multipliers</th>
-      </thead>
+      </thead> -->
       <tbody>
         <tr class="table-secondary">
+          <th colspan="3">Resolution factors</th>
+        </tr>
+        <tr>
           <th class="col-3">SD</th>
           <th class="col-3">HD</th>
           <th class="col-3">4k UHD</th>
@@ -131,6 +134,9 @@
           <td>4</td>
         </tr>
         <tr class="table-secondary">
+          <th colspan="3">Feature factors</th>
+        </tr>
+        <tr>
           <th>3-Pass</th>
           <th colspan="2"></th>
         </tr>
@@ -139,8 +145,11 @@
           <td colspan="2"></td>
         </tr>
         <tr class="table-secondary">
-          <th>H264</th>
-          <th>H265</th>
+          <th colspan="3">Codec factors</th>
+        </tr>
+        <tr>
+          <th>H.264</th>
+          <th>H.265</th>
           <th>AV1</th>
         </tr>
         <tr>
@@ -149,8 +158,11 @@
           <td>10</td>
         </tr>
         <tr class="table-secondary">
-          <th>AV1 efficiency improvement over H.264</th>
-          <th>AV1 efficiency improvement over H.265</th>
+          <th colspan="3">Efficiency improvements</th>
+        </tr>
+        <tr>
+          <th>AV1 over H.264</th>
+          <th>AV1 over H.265</th>
           <th></th>
         </tr>
         <tr>

--- a/encoding/av1-break-even-calculator/index.html
+++ b/encoding/av1-break-even-calculator/index.html
@@ -168,9 +168,9 @@
     <li class="mb-2" style="font-size: 12px;">
       <span id="formulaFootnote">
         For the break-even point calculation we calculated the number of views such as:
-        [H.26X encoding cost] + ( [views] * [H.26X CDN delivery cost] )
+        ([views] * [H.26X CDN delivery cost]) + [H.26X encoding cost]
         is equal to
-        [H.26X encoding cost] + [AV1 encoding cost] + ( [views] * [AV1 CDN delivery cost] )
+        ([views] * [AV1 CDN delivery cost]) + [H.26X encoding cost] + [AV1 encoding cost]
       </span>
     </li>
   </ol>

--- a/encoding/av1-break-even-calculator/index.html
+++ b/encoding/av1-break-even-calculator/index.html
@@ -19,7 +19,7 @@
                 min="0.00"
                 step="0.0001"
                 type="number"
-                value="0.020" />
+                value="0.02" />
           <div class="input-group-append"><span class="input-group-text">$</span></div>
         </div>
         <div>

--- a/encoding/av1-break-even-calculator/index.html
+++ b/encoding/av1-break-even-calculator/index.html
@@ -99,7 +99,9 @@
 
 <p class="text-justify">
   For ease of comparison this calculator uses a fixed ladder.
-  We recommend to use Per-Title as it can help reduce the break-even point further.
+  We recommend to use
+  <a href="https://bitmovin.com/per-title-encoding/" rel="noreferrer" target="_blank" style="font-size: inherit;">Per-Title</a>
+  as it can help reduce the break-even point further.
   It will optimize each ladder individually, usually resulting in a reduced number of
   renditions for more advanced codecs, hence reduced encoding and storage costs
   compared to a fixed ladder.

--- a/encoding/av1-break-even-calculator/index.html
+++ b/encoding/av1-break-even-calculator/index.html
@@ -27,21 +27,6 @@
         </div>
       </div>
       <div class="form-group">
-        <label for="ingressCostPerGb">Ingress cost per GB</label>
-        <div class="input-group">
-          <input class="form-control"
-                id="ingressCostPerGb"
-                min="0"
-                step="0.01"
-                type="number"
-                value="0" />
-          <div class="input-group-append"><span class="input-group-text">$</span></div>
-        </div>
-        <div>
-          <small>&nbsp;</small>
-        </div>
-      </div>
-      <div class="form-group">
         <label for="egressCostPerGb">CDN delivery cost per GB</label>
         <div class="input-group">
           <input class="form-control"
@@ -93,11 +78,8 @@
     </div>
 
   </div>
-</form>
-
-<div class="container">
+  
   <div class="row">
-
     <div class="col-md-6 my-2">
       <div>Break-even point - H.264+AV1 vs H.264 only</div>
       <div id="av1-h264" class="font-weight-bold" style="font-size: 24px">--</div>
@@ -107,9 +89,9 @@
       <div>Break-even point - H.265+AV1 vs H.265 only</div>
       <div id="av1-h265" class="font-weight-bold" style="font-size: 24px">--</div>
     </div>
-
   </div>
-</div>
+</form>
+
 <p class="text-justify">
   Starting from these numbers of views, supplementing encodings with AV1 becomes more
   profitable than the respective codec alone. 

--- a/encoding/av1-break-even-calculator/index.html
+++ b/encoding/av1-break-even-calculator/index.html
@@ -16,10 +16,10 @@
         <div class="input-group">
           <input class="form-control"
                 id="encodingCostPerMinute"
-                min="0"
-                step="0.01"
+                min="0.00"
+                step="0.0001"
                 type="number"
-                value="0.02" />
+                value="0.020" />
           <div class="input-group-append"><span class="input-group-text">$</span></div>
         </div>
         <div>
@@ -31,8 +31,8 @@
         <div class="input-group">
           <input class="form-control"
                 id="egressCostPerGb"
-                min="0"
-                step="0.01"
+                min="0.00"
+                step="0.0001"
                 type="number"
                 value="0.04" />
           <div class="input-group-append"><span class="input-group-text">$</span></div>  

--- a/encoding/av1-break-even-calculator/index.html
+++ b/encoding/av1-break-even-calculator/index.html
@@ -43,7 +43,7 @@
     <div class="col-md-6">
       
       <div class="form-group">
-        <label for="numberOfStreamsUhd">Number of 4K UHD streams (H.264 bitrate: 12 Mbps; billing multiplier: 4)</label>
+        <label for="numberOfStreamsUhd">Number of 4k UHD streams (H.264 bitrate: 12 Mbps; billing multiplier: 4)</label>
         <input class="form-control"
               id="numberOfStreamsUhd"
               min="1"
@@ -123,7 +123,7 @@
         <tr class="table-secondary">
           <th class="col-3">SD</th>
           <th class="col-3">HD</th>
-          <th class="col-3">UHD</th>
+          <th class="col-3">4k UHD</th>
         </tr>
         <tr>
           <td>1</td>

--- a/encoding/av1-break-even-calculator/index.html
+++ b/encoding/av1-break-even-calculator/index.html
@@ -97,6 +97,14 @@
   profitable than the respective codec alone. 
 </p>
 
+<p class="text-justify">
+  For ease of comparison this calculator uses a fixed ladder.
+  We recommend to use Per-Title as it can help reduce the break-even point further.
+  It will optimize each ladder individually, usually resulting in a reduced number of
+  renditions for more advanced codecs, hence reduced encoding and storage costs
+  compared to a fixed ladder.
+</p>
+
 <h3 class="my-3">Calculation multipliers</h3>
 <p class="text-justify">
   These are the multipliers and factors used in our calculation<a href="#formulaFootnote" target="_self" class="btm-footnote"></a>.

--- a/encoding/av1-break-even-calculator/js/av1-break-even-calculator.js
+++ b/encoding/av1-break-even-calculator/js/av1-break-even-calculator.js
@@ -48,21 +48,21 @@ $(function() {
   (function initAv1Form() {
     // form values for calculation
     let encodingCostPerMinute = 0.02;
-    let ingressCostPerGb = 0.00;
     let egressCostPerGb = 0.04;
-
+    
     let numberOfStreamsUhd = 2;
     let numberOfStreamsHd = 3;
     let numberOfStreamsSd = 4;
-
+    
     const multiplierStreamUhd = 4;
     const multiplierStreamHd = 2;
     const multiplierStreamSd = 1;
     const multiplierTechPerTitle = 1.1;
     const multiplierTech3Pass = 2; // Multipass
     const multiplierCodecAv1 = 10;
-
+    
     // streams/renditions
+    const ingressCostPerGb = 0.00;
     const improvementsAv1H264 = 0.5; // 50%
     const improvementsAv1H265 = 0.7; // 30%
     const mbpsH264Uhd = 12;
@@ -118,12 +118,6 @@ $(function() {
     $('input#encodingCostPerMinute', formElement).val(encodingCostPerMinute)
       .on('input', inputEventHandler((value) => {
         encodingCostPerMinute = value;
-        calculateBreakEvenPoints();
-      }));
-    
-    $('input#ingressCostPerGb', formElement).val(ingressCostPerGb)
-      .on('input', inputEventHandler((value) => {
-        ingressCostPerGb = value;
         calculateBreakEvenPoints();
       }));
     

--- a/encoding/av1-break-even-calculator/js/av1-break-even-calculator.js
+++ b/encoding/av1-break-even-calculator/js/av1-break-even-calculator.js
@@ -35,7 +35,7 @@ $(function() {
 
       var numberValue = Number(e.target.value);
       if (isNaN(numberValue) || numberValue < 0
-        || countDecimals(numberValue) > 2) {
+        || countDecimals(numberValue) > 4) {
         inputEl.addClass('is-invalid');
         onInputValue(NaN);
         return;

--- a/encoding/av1-break-even-calculator/js/av1-break-even-calculator.js
+++ b/encoding/av1-break-even-calculator/js/av1-break-even-calculator.js
@@ -57,7 +57,6 @@ $(function() {
     const multiplierStreamUhd = 4;
     const multiplierStreamHd = 2;
     const multiplierStreamSd = 1;
-    const multiplierTechPerTitle = 1.1;
     const multiplierTech3Pass = 2; // Multipass
     const multiplierCodecAv1 = 10;
     
@@ -82,7 +81,7 @@ $(function() {
         + numberOfStreamsHd * multiplierStreamHd
         + numberOfStreamsSd * multiplierStreamSd;
       const encodingCostPerMinuteAv1 = encodingCostPerMinute * multiplierStreamComposition
-        * multiplierTech3Pass * multiplierTechPerTitle * multiplierCodecAv1;
+        * multiplierTech3Pass * multiplierCodecAv1;
 
       // all stream bandwidth
       const multiplierStreamCompositionMbps = numberOfStreamsUhd * mbpsH264Uhd


### PR DESCRIPTION
This PR will improve the "AV1 break-even calculator" form the encoding demos: https://bitmovin.atlassian.net/browse/EN-11519

- improve copy text for description and footnote formula
- enable 4-digit dollar inputs, e.g. "0.0123$"
- remove "ingress cost" input
- remove Per-Title from factors and formula
- structure Calculation multipliers table into factors

![Screenshot 2022-07-20 at 11-08-46 AV1 break-even point calculator » Demo Bitmovin](https://user-images.githubusercontent.com/24493844/179944027-d1d88127-f899-40bf-8d3e-909664b4b531.png)

Relates to https://github.com/bitmovin/demos/pull/92