### PR TITLE
Add missing `var` to avoid error in `strict` mode

### DIFF
--- a/player/custom-adaptation/js/script.js
+++ b/player/custom-adaptation/js/script.js
@@ -139,7 +139,7 @@
   };
 
   var playerContainer = document.getElementById('player-container');
-  player = new bitmovin.player.Player(playerContainer, conf);
+  var player = new bitmovin.player.Player(playerContainer, conf);
 
   player.load(source).then(function () {
     availableRepresentations = player.getAvailableVideoQualities();


### PR DESCRIPTION
Missing `var` causes an error when because of JS' `strict mode` and breaks the demo. Adding it in this PR to make the demo work again.