### PR TITLE
Fix player appearance on Stream Test page

### DIFF
--- a/player/stream-test/css/style.css
+++ b/player/stream-test/css/style.css
@@ -166,6 +166,7 @@ body:not(.fullscreen) :not(.no-frame).notebook-frame::before {
 
 .demo-row {
     display: flex;
+    align-items: flex-start;
 }
 
 .demo-start {


### PR DESCRIPTION
Following up on https://github.com/bitmovin/demos/pull/102.

Fixes

![image](https://user-images.githubusercontent.com/85180621/223371068-3fb2d91b-8e18-4f2b-8665-6c760cfdbafc.png)

to be

![image](https://user-images.githubusercontent.com/85180621/223370996-55836b69-cb35-4ba5-963b-dbdb8b095b02.png)
