### PR TITLE
[untracked] Migrate PlayReady LA URLs to new servers.

### DIFF
--- a/player/drm/demo.js
+++ b/player/drm/demo.js
@@ -14,7 +14,7 @@ var source = {
       LA_URL: 'https://cwip-shaka-proxy.appspot.com/no_auth'
     },
     playready: {
-      LA_URL: 'https://playready.directtaps.net/pr/svc/rightsmanager.asmx?PlayRight=1&ContentKey=EAtsIJQPd5pFiRUrV9Layw=='
+      LA_URL: 'https://test.playready.microsoft.com/service/rightsmanager.asmx?PlayRight=1&ContentKey=EAtsIJQPd5pFiRUrV9Layw=='
     }
   }
 };

--- a/player/drm/js/script.js
+++ b/player/drm/js/script.js
@@ -15,7 +15,7 @@
         'LA_URL': 'https://cwip-shaka-proxy.appspot.com/no_auth'
       },
       'playready': {
-        'LA_URL': 'https://playready.directtaps.net/pr/svc/rightsmanager.asmx?PlayRight=1&ContentKey=EAtsIJQPd5pFiRUrV9Layw=='
+        'LA_URL': 'https://test.playready.microsoft.com/service/rightsmanager.asmx?PlayRight=1&ContentKey=EAtsIJQPd5pFiRUrV9Layw=='
       }
     }
   };

--- a/player/stream-test/js/script.js
+++ b/player/stream-test/js/script.js
@@ -72,7 +72,7 @@ var drmSource = {
   drm: {
     none: '',
     widevine: 'https://cwip-shaka-proxy.appspot.com/no_auth',
-    playready: 'https://playready.directtaps.net/pr/svc/rightsmanager.asmx?PlayRight=1&ContentKey=EAtsIJQPd5pFiRUrV9Layw=='
+    playready: 'https://test.playready.microsoft.com/service/rightsmanager.asmx?PlayRight=1&ContentKey=EAtsIJQPd5pFiRUrV9Layw=='
   }
 };
 


### PR DESCRIPTION
PlayReady license requests to the URLs that we currently use are failing with an internal server error.

There are updated test server endpoints available: https://testweb.playready.microsoft.com/#march-15th-2017-migration-of-the-old-test-servers

This PR replaces all legacy `playready.directtaps.net` LA URLs to the updated `test.playready.microsoft.com`.