### PR TITLE
Update low latency player demo

### DIFF
--- a/player/low-latency-streaming/index.html
+++ b/player/low-latency-streaming/index.html
@@ -65,7 +65,7 @@
                     Target Latency: <span id="targetLatency">2</span>
                 </div>
                 <div class="slide-container">
-                    <input type="range" min="0.5" max="5" value="2" step="0.1" class="slider" id="targetLatencySlider">
+                    <input type="range" min="3" max="7" value="5" step="0.1" class="slider" id="targetLatencySlider">
                     <div class="latency-status-row">
                         <div>Low</div>
                         <div style="text-align: right">High</div>

--- a/player/low-latency-streaming/index.html
+++ b/player/low-latency-streaming/index.html
@@ -1,7 +1,7 @@
 <script type="text/javascript"
-        src="//cdn.bitmovin.com/player/web/8.4.0/bitmovinplayer.js"></script>
+        src="https://cdn.jsdelivr.net/npm/bitmovin-player@latest/bitmovinplayer.js"></script>
 <script type="text/javascript"
-        src="https://cdn.bitmovin.com/analytics/web/beta/2/bitmovinanalytics.min.js"></script>
+        src="https://cdn.jsdelivr.net/npm/bitmovin-analytics@latest/bitmovinanalytics.min.js"></script>
 
 <div class="row">
     <div class="col-lg-6">

--- a/player/low-latency-streaming/js/script.js
+++ b/player/low-latency-streaming/js/script.js
@@ -10,7 +10,7 @@ var targetLatencyDisplay = document.querySelector('#targetLatency');
 
 var targetLatency = 3;
 var videoOnly = false;
-var dashUrl = 'https://akamaibroadcasteruseast.akamaized.net/cmaf/live/657078/akasource/out.mpd';
+var dashUrl = 'https://cmafref.akamaized.net/cmaf/live-ull/2006350/akambr/out.mpd';
 
 var queryString = getQueryParams();
 

--- a/player/low-latency-streaming/js/script.js
+++ b/player/low-latency-streaming/js/script.js
@@ -8,7 +8,7 @@ var latencyDisplay = document.querySelector('#latency');
 var slider = document.querySelector('#targetLatencySlider');
 var targetLatencyDisplay = document.querySelector('#targetLatency');
 
-var targetLatency = 3;
+var targetLatency = 5;
 var videoOnly = false;
 var dashUrl = 'https://cmafref.akamaized.net/cmaf/live-ull/2006350/akambr/out.mpd';
 

--- a/player/low-latency-streaming/js/script.js
+++ b/player/low-latency-streaming/js/script.js
@@ -50,6 +50,7 @@ var conf = {
         muted: true,
     },
     adaptation: {
+        logic: 'low-latency-v1',
         preload: false,
     },
     logs: {
@@ -116,8 +117,6 @@ function printBufferLevels() {
 function loadPlayer() {
     player = new bitmovin.player.Player(document.getElementById('player-container'), conf);
     player.load(source).then(function() {
-    // ABR is not supported yet for low latency
-    player.setVideoQuality(player.getAvailableVideoQualities()[0].id);
     updateTargetLatency();
 
     if (isFirefox) {


### PR DESCRIPTION
Update the low latency player demo:

- Use latest player and analytics versions
- Switch to a multi-bitrate stream
- Use low-latency-v1 ABR