### PR TITLE
[PW-10478] Quality stability slider

### DIFF
--- a/player/low-latency-streaming/css/style.css
+++ b/player/low-latency-streaming/css/style.css
@@ -142,11 +142,15 @@
     border: 3px solid #1FAAE2;
 }
 
-.latency-control {
+.latency-control, .quality-control {
     padding: 35px 20px 10px 20px;
     margin: 7px;
     font-size: 15px;
     width: 100%;
+}
+
+.quality-control {
+    padding-top: 0px;
 }
 
 #firefoxWarning {

--- a/player/low-latency-streaming/index.html
+++ b/player/low-latency-streaming/index.html
@@ -75,7 +75,7 @@
                     Quality-Stability Tradeoff: <span id="qualityStability">0.5</span>
                 </div>
                 <div class="slide-container">
-                    <input type="range" min="0" max="1" value="0.5" step="0.01" class="slider" id="qualtyStabilitySlider">
+                    <input type="range" min="0" max="1" value="0.3" step="0.01" class="slider" id="qualtyStabilitySlider">
                     <div class="latency-status-row">
                         <div>Quality</div>
                         <div style="text-align: right">Stability</div>

--- a/player/low-latency-streaming/index.html
+++ b/player/low-latency-streaming/index.html
@@ -71,7 +71,7 @@
                 </div>
             </div>
             <div class="quality-control">
-                <div>
+                <div title="Defines the balance between quality (i.e. bitrate) and stability in a range of [0, 1].&#013;0 means that the player will aim to play the best possible quality, potentially at the cost of lower playback stability.&#013;1 means that the player will aim for the highest stability with the least amount of stalls, while potentially sacrificing quality.">
                     Quality-Stability Tradeoff: <span id="qualityStability">0.3</span>
                 </div>
                 <div class="slide-container">

--- a/player/low-latency-streaming/index.html
+++ b/player/low-latency-streaming/index.html
@@ -70,6 +70,18 @@
                     </div>
                 </div>
             </div>
+            <div class="quality-control">
+                <div>
+                    Quality-Stability Tradeoff: <span id="qualityStability">0.5</span>
+                </div>
+                <div class="slide-container">
+                    <input type="range" min="0" max="1" value="0.5" step="0.01" class="slider" id="qualtyStabilitySlider">
+                    <div class="latency-status-row">
+                        <div>Quality</div>
+                        <div style="text-align: right">Stability</div>
+                    </div>
+                </div>
+            </div>
             <div id="firefoxWarning">
             </div>
         </div>

--- a/player/low-latency-streaming/index.html
+++ b/player/low-latency-streaming/index.html
@@ -72,7 +72,7 @@
             </div>
             <div class="quality-control">
                 <div>
-                    Quality-Stability Tradeoff: <span id="qualityStability">0.5</span>
+                    Quality-Stability Tradeoff: <span id="qualityStability">0.3</span>
                 </div>
                 <div class="slide-container">
                     <input type="range" min="0" max="1" value="0.3" step="0.01" class="slider" id="qualtyStabilitySlider">

--- a/player/low-latency-streaming/js/script.js
+++ b/player/low-latency-streaming/js/script.js
@@ -5,7 +5,9 @@ var audioBufferDisplay = document.querySelector('#audioBufferLength');
 var playbackSpeedDisplay = document.querySelector('#playbackSpeed');
 var timeDisplay = document.querySelector('#time');
 var latencyDisplay = document.querySelector('#latency');
-var slider = document.querySelector('#targetLatencySlider');
+var latencySlider = document.querySelector('#targetLatencySlider');
+var qualityStabilityDisplay = document.querySelector('#qualityStability');
+var qualityStabilitySlider = document.querySelector('#qualtyStabilitySlider');
 var targetLatencyDisplay = document.querySelector('#targetLatency');
 
 var targetLatency = 5;
@@ -31,13 +33,25 @@ if (queryString.dashUrl) {
 }
 
 var updateTargetLatency = function() {
-    targetLatencyDisplay.innerText = slider.value + 's';
-    targetLatency = Number(slider.value);
+    targetLatencyDisplay.innerText = latencySlider.value + 's';
+    targetLatency = Number(latencySlider.value);
     player.lowlatency.setTargetLatency(targetLatency);
 };
 
-slider.oninput = updateTargetLatency;
-slider.value = String(targetLatency);
+latencySlider.oninput = updateTargetLatency;
+latencySlider.value = String(targetLatency);
+
+var updateQualityStability = function() {
+    var targetValue = Number(qualityStabilitySlider.value);
+    if (isNaN(targetValue) || targetValue < 0 || targetValue > 1) {
+        console.warn('Invalid value for qualityStabilityBalance: ', targetValue);
+        return;
+    }
+    console.log('Setting qualityStabilityBalence to', targetValue);
+    player.adaptation.setConfig({qualityStabilityBalance: targetValue});
+    qualityStabilityDisplay.innerText = targetValue;
+}
+qualityStabilitySlider.oninput = updateQualityStability;
 
 var conf = {
     key: '29ba4a30-8b5e-4336-a7dd-c94ff3b25f30',
@@ -50,10 +64,7 @@ var conf = {
         muted: true,
     },
     adaptation: {
-        logic: 'low-latency-v1',
         preload: false,
-        // Encourage switching to a higher quality sooner
-        qualityStabilityBalance: 0.3,
     },
     logs: {
         //level: 'debug'

--- a/player/low-latency-streaming/js/script.js
+++ b/player/low-latency-streaming/js/script.js
@@ -47,7 +47,6 @@ var updateQualityStability = function() {
         console.warn('Invalid value for qualityStabilityBalance: ', targetValue);
         return;
     }
-    console.log('Setting qualityStabilityBalence to', targetValue);
     player.adaptation.setConfig({qualityStabilityBalance: targetValue});
     qualityStabilityDisplay.innerText = targetValue;
 }

--- a/player/low-latency-streaming/js/script.js
+++ b/player/low-latency-streaming/js/script.js
@@ -63,6 +63,7 @@ var conf = {
         muted: true,
     },
     adaptation: {
+        logic: 'low-latency-v1',
         preload: false,
         // Encourage switching to a higher quality sooner
         qualityStabilityBalance: 0.3,

--- a/player/low-latency-streaming/js/script.js
+++ b/player/low-latency-streaming/js/script.js
@@ -64,6 +64,8 @@ var conf = {
     },
     adaptation: {
         preload: false,
+        // Encourage switching to a higher quality sooner
+        qualityStabilityBalance: 0.3,
     },
     logs: {
         //level: 'debug'


### PR DESCRIPTION
Since we now have a way to influence the players behavior when it comes to choosing the quality in LL environments, we decided to update the LL demo to include it.

BigScreen:
![image](https://github.com/bitmovin/demos/assets/29116195/77718638-0f59-42f1-9e55-ed766aa80a94)


Smaller Screen:
![image](https://github.com/bitmovin/demos/assets/29116195/187dbe99-01aa-4185-b456-f1525f55ae71)
