### PR TITLE
Use explicit version of fflate

### DIFF
--- a/player/cmcd/index.html
+++ b/player/cmcd/index.html
@@ -2,7 +2,7 @@
 <script src="https://cdn.jsdelivr.net/npm/bitmovin-analytics@latest/bitmovinanalytics.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/uuid@8.3.2/dist/umd/uuidv4.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/x2js@3.4.4/x2js.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/fflate/umd/index.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/fflate@0.7.4/umd/index.js"></script>
 
 <div class="description">
     <p>This demo showcases how Common Media Client Data (CMCD) can be sent by the Player to a CDN.</p>


### PR DESCRIPTION
Using the latest URL resulted in fflate not being defined in the browser, pinning it to a specific version instead.