### PR TITLE
Fix latency mode display

### DIFF
--- a/player/low-latency-streaming/js/script.js
+++ b/player/low-latency-streaming/js/script.js
@@ -76,8 +76,8 @@ var conf = {
     },
     style: {},
     events: {
-        playbackspeedchanged: function(e) {
-        playbackSpeedDisplay.innerText = e.to;
+        [bitmovin.player.PlayerEvent.LatencyModeChanged]: function(e) {
+            playbackSpeedDisplay.innerText = e.to;
         },
     },
     tweaks: {


### PR DESCRIPTION
The latency mode was always displayed as `1` since it only reacted to PlaybackSpeed changes.
The player does not expose the playback speed changes it does due to LowLatency mode changing. So I changed it to actually listen to the `LatencyModeChanged` event and display one of the modes:
- `catchup`
- `fallback`
- `idle`
- `suspended`