### PR TITLE
Fix initial latency mode

### DIFF
--- a/player/low-latency-streaming/index.html
+++ b/player/low-latency-streaming/index.html
@@ -54,7 +54,7 @@
                 <div class="latency-status-row">
                     <div>Latency Mode</div>
                     <div>
-                        <span id="playbackSpeed">1</span>
+                        <span id="playbackSpeed">suspended</span>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
The initial latency mode was still displayed as `1`. When the first LatencyModeChanged event comes it reports switching `from` "suspended" to x, so I updated the initial value to represent the `suspended` state.