### PR TITLE
Default HLS DRM source on Safari

### DIFF
--- a/player/drm/js/script.js
+++ b/player/drm/js/script.js
@@ -308,6 +308,9 @@
     if (browser === BROWSER.IE || browser === BROWSER.EDGE) {
       document.querySelector('#available-manifest-type').selectedIndex = 2;
     }
+    if (browser === BROWSER.SAFARI) {
+      document.querySelector('#available-manifest-type').selectedIndex = 1;
+    }
   }
 
   getSupportedDRMSystem(true).then(function () {


### PR DESCRIPTION
The DRM demo is not working on safari browser as it picks the wrong unsupported source(Dash with Fairplay).

This PR picks HLS source by default when safari browser is detected.