### PR TITLE
Move HLS source first in the source list

### DIFF
--- a/player/ad-event-verification-omsdk/js/script.js
+++ b/player/ad-event-verification-omsdk/js/script.js
@@ -19,8 +19,8 @@ var conf = {
     },
 };
 var source = {
-    dash: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd',
     hls: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/m3u8s/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8',
+    dash: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd',
     progressive: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/MI201109210084_mpeg-4_hd_high_1080p25_10mbits.mp4',
     poster: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/poster.jpg'
 };

--- a/player/ad-event-verification/js/script.js
+++ b/player/ad-event-verification/js/script.js
@@ -18,8 +18,8 @@ var conf = {
 };
 
 var source = {
-  dash: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd',
   hls: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/m3u8s/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8',
+  dash: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd',
   progressive: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/MI201109210084_mpeg-4_hd_high_1080p25_10mbits.mp4',
   poster: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/poster.jpg'
 };

--- a/player/ad-event-verification/setup.js
+++ b/player/ad-event-verification/setup.js
@@ -3,8 +3,8 @@ var conf = {
 };
 
 var source = {
-  dash: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd',
   hls: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/m3u8s/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8',
+  dash: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd',
   progressive: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/MI201109210084_mpeg-4_hd_high_1080p25_10mbits.mp4',
   poster: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/poster.jpg'
 };

--- a/player/ad-scheduling/js/script.js
+++ b/player/ad-scheduling/js/script.js
@@ -23,8 +23,8 @@ var conf = {
 };
 
 var source = {
-  dash: '//cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd',
   hls: '//cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/m3u8s/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8',
+  dash: '//cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd',
   progressive: '//cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/MI201109210084_mpeg-4_hd_high_1080p25_10mbits.mp4',
   poster: '//cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/poster.jpg'
 };
@@ -103,8 +103,8 @@ function removeSchedule() {
 
   player = new bitmovin.player.Player(playerContainer, conf);
   player.load({
-    dash: '//cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd',
     hls: '//cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/m3u8s/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8',
+    dash: '//cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd',
     progressive: '//cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/MI201109210084_mpeg-4_hd_high_1080p25_10mbits.mp4',
     poster: '//cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/poster.jpg'
   });

--- a/player/caption-styling/demo.js
+++ b/player/caption-styling/demo.js
@@ -3,8 +3,8 @@ var conf = {
 };
 
 var source = {
-  dash: 'https://cdn.bitmovin.com/content/assets/sintel/sintel.mpd',
   hls: 'https://cdn.bitmovin.com/content/assets/sintel/hls/playlist.m3u8',
+  dash: 'https://cdn.bitmovin.com/content/assets/sintel/sintel.mpd',
   poster: 'https://cdn.bitmovin.com/content/assets/sintel/poster.png'
 };
 

--- a/player/caption-styling/js/script.js
+++ b/player/caption-styling/js/script.js
@@ -10,8 +10,8 @@ var conf = {
 };
 
 var source = {
-  dash: 'https://cdn.bitmovin.com/content/assets/sintel/sintel.mpd',
   hls: 'https://cdn.bitmovin.com/content/assets/sintel/hls/playlist.m3u8',
+  dash: 'https://cdn.bitmovin.com/content/assets/sintel/sintel.mpd',
   poster: 'https://cdn.bitmovin.com/content/assets/sintel/poster.png'
 };
 

--- a/player/channel-switching/js/script.js
+++ b/player/channel-switching/js/script.js
@@ -121,22 +121,22 @@ function switchChannel(channelID, event) {
       source = {
         title: 'Art of Motion',
         description: 'What is this event... Parcour?',
+        hls: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/m3u8s/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8',
         dash: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd',
-        hls: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/m3u8s/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8'
       }
     } else if (channelID === '2') {
       source = {
         title: 'Big Buck Bunny',
         description: 'A day in the life of Big Buck Bunny.',
+        hls: 'https://cdn.bitmovin.com/content/assets/bbb/stream.m3u8',
         dash: 'https://cdn.bitmovin.com/content/assets/bbb/stream.mpd',
-        hls: 'https://cdn.bitmovin.com/content/assets/bbb/stream.m3u8'
       };
     } else {
       source = {
         title: 'Sintel',
         description: 'The main character, Sintel, is attacked while traveling through a wintry mountainside.',
-        dash: 'https://cdn.bitmovin.com/content/assets/sintel/sintel.mpd',
         hls: 'https://cdn.bitmovin.com/content/assets/sintel/hls/playlist.m3u8',
+        dash: 'https://cdn.bitmovin.com/content/assets/sintel/sintel.mpd',
         poster: 'https://cdn.bitmovin.com/content/assets/sintel/poster.png'
       }
     }

--- a/player/channel-switching/switchChannel.js
+++ b/player/channel-switching/switchChannel.js
@@ -4,22 +4,22 @@ function switchChannel(channelID) {
     source = {
       title: 'Art of Motion',
       description: 'What is this event... Parcour?',
+      hls: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/m3u8s/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8',
       dash: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd',
-      hls: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/m3u8s/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8'
     }
   } else if (channelID === '2') {
     source = {
       title: 'Big Buck Bunny',
       description: 'A day in the life of Big Buck Bunny.',
+      hls: 'https://cdn.bitmovin.com/content/assets/bbb/stream.m3u8',
       dash: 'https://cdn.bitmovin.com/content/assets/bbb/stream.mpd',
-      hls: 'https://cdn.bitmovin.com/content/assets/bbb/stream.m3u8'
     };
   } else {
     source = {
       title: 'Sintel',
       description: 'The main character, Sintel, is attacked while traveling through a wintry mountainside.',
-      dash: 'https://cdn.bitmovin.com/content/assets/sintel/sintel.mpd',
       hls: 'https://cdn.bitmovin.com/content/assets/sintel/hls/playlist.m3u8',
+      dash: 'https://cdn.bitmovin.com/content/assets/sintel/sintel.mpd',
       poster: 'https://cdn.bitmovin.com/content/assets/sintel/poster.png'
     }
   }

--- a/player/chromecast/demo.js
+++ b/player/chromecast/demo.js
@@ -6,10 +6,10 @@ var conf = {
 };
 
 var source = {
-  dash:
-    'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd',
   hls:
     'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/m3u8s/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8',
+  dash:
+    'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd',
   progressive:
     'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/MI201109210084_mpeg-4_hd_high_1080p25_10mbits.mp4',
   poster:

--- a/player/chromecast/js/script.js
+++ b/player/chromecast/js/script.js
@@ -13,8 +13,8 @@ var conf = {
 };
 
 var source = {
-  dash: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd',
   hls: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/m3u8s/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8',
+  dash: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd',
   progressive: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/MI201109210084_mpeg-4_hd_high_1080p25_10mbits.mp4',
   poster: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/poster.jpg'
 };

--- a/player/chromeless/demo.js
+++ b/player/chromeless/demo.js
@@ -8,8 +8,8 @@ var conf = {
 };
 
 var source = {
-  dash: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd',
   hls: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/m3u8s/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8',
+  dash: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd',
   progressive: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/MI201109210084_mpeg-4_hd_high_1080p25_10mbits.mp4',
   poster: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/poster.jpg'
 };

--- a/player/chromeless/js/script.js
+++ b/player/chromeless/js/script.js
@@ -12,8 +12,8 @@ var conf = {
 };
 
 var source = {
-  dash: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd',
   hls: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/m3u8s/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8',
+  dash: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd',
   progressive: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/MI201109210084_mpeg-4_hd_high_1080p25_10mbits.mp4',
   poster: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/poster.jpg'
 };

--- a/player/custom-adaptation/demo.js
+++ b/player/custom-adaptation/demo.js
@@ -20,8 +20,8 @@ var conf = {
 };
 
 var source = {
-  dash: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd',
   hls: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/m3u8s/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8',
+  dash: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd',
   progressive: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/MI201109210084_mpeg-4_hd_high_1080p25_10mbits.mp4',
   poster: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/poster.jpg',
 };

--- a/player/custom-adaptation/js/script.js
+++ b/player/custom-adaptation/js/script.js
@@ -132,8 +132,8 @@
   };
 
   var source = {
-    dash: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd',
     hls: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/m3u8s/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8',
+    dash: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd',
     progressive: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/MI201109210084_mpeg-4_hd_high_1080p25_10mbits.mp4',
     poster: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/poster.jpg',
   };

--- a/player/custom-quality-labels/setup.js
+++ b/player/custom-quality-labels/setup.js
@@ -11,8 +11,8 @@ var conf = {
   };
   
 var source = {
-  dash: 'https://cdn.bitmovin.com/content/assets/sintel/sintel.mpd',
   hls: 'https://cdn.bitmovin.com/content/assets/sintel/hls/playlist.m3u8',
+  dash: 'https://cdn.bitmovin.com/content/assets/sintel/sintel.mpd',
   poster: 'https://cdn.bitmovin.com/content/assets/sintel/poster.png',
   labeling: {
     dash: {

--- a/player/drm/demo.js
+++ b/player/drm/demo.js
@@ -6,8 +6,8 @@ var config = {
 };
 
 var source = {
-  dash: 'https://cdn.bitmovin.com/content/assets/art-of-motion_drm/mpds/11331.mpd',
   hls: 'https://cdn.bitmovin.com/content/assets/art-of-motion_drm/m3u8s/11331.m3u8',
+  dash: 'https://cdn.bitmovin.com/content/assets/art-of-motion_drm/mpds/11331.mpd',
   smooth: 'https://test.playready.microsoft.com/smoothstreaming/SSWSS720H264/SuperSpeedway_720.ism/manifest',
   drm: {
     widevine: {

--- a/player/drm/js/script.js
+++ b/player/drm/js/script.js
@@ -308,9 +308,6 @@
     if (browser === BROWSER.IE || browser === BROWSER.EDGE) {
       document.querySelector('#available-manifest-type').selectedIndex = 2;
     }
-    if (browser === BROWSER.SAFARI) {
-      document.querySelector('#available-manifest-type').selectedIndex = 1;
-    }
   }
 
   getSupportedDRMSystem(true).then(function () {

--- a/player/multi-audio-tracks/js/script.js
+++ b/player/multi-audio-tracks/js/script.js
@@ -10,8 +10,8 @@ var conf = {
 };
 
 var source = {
-  dash: 'https://cdn.bitmovin.com/content/assets/sintel/sintel.mpd',
   hls: 'https://cdn.bitmovin.com/content/assets/sintel/hls/playlist.m3u8',
+  dash: 'https://cdn.bitmovin.com/content/assets/sintel/sintel.mpd',
   poster: 'https://cdn.bitmovin.com/content/assets/sintel/poster.png'
 };
 

--- a/player/multi-audio-tracks/setup.js
+++ b/player/multi-audio-tracks/setup.js
@@ -3,8 +3,8 @@ var conf = {
 };
 
 var source = {
-  dash: 'https://cdn.bitmovin.com/content/assets/sintel/sintel.mpd',
   hls: 'https://cdn.bitmovin.com/content/assets/sintel/hls/playlist.m3u8',
+  dash: 'https://cdn.bitmovin.com/content/assets/sintel/sintel.mpd',
   poster: 'https://cdn.bitmovin.com/content/assets/sintel/poster.png',
 };
 

--- a/player/native-sdks/js/script.js
+++ b/player/native-sdks/js/script.js
@@ -10,8 +10,8 @@ var conf = {
 }
 
 var source = {
-  dash: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd',
   hls: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/m3u8s/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8',
+  dash: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd',
   progressive: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/MI201109210084_mpeg-4_hd_high_1080p25_10mbits.mp4',
   poster: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/poster.jpg'
 };

--- a/player/overlay-ad/js/script.js
+++ b/player/overlay-ad/js/script.js
@@ -18,8 +18,8 @@ var conf = {
 };
 
 var source = {
-  dash: 'https://cdn.bitmovin.com/content/assets/sintel/sintel.mpd',
   hls: 'https://cdn.bitmovin.com/content/assets/sintel/hls/playlist.m3u8',
+  dash: 'https://cdn.bitmovin.com/content/assets/sintel/sintel.mpd',
   poster: 'https://cdn.bitmovin.com/content/assets/sintel/poster.png'
 };
 

--- a/player/overlay-ad/setup.js
+++ b/player/overlay-ad/setup.js
@@ -14,8 +14,8 @@ var conf = {
 };
   
 var source = {
-  dash: 'https://cdn.bitmovin.com/content/assets/sintel/sintel.mpd',
   hls: 'https://cdn.bitmovin.com/content/assets/sintel/hls/playlist.m3u8',
+  dash: 'https://cdn.bitmovin.com/content/assets/sintel/sintel.mpd',
   poster: 'https://cdn.bitmovin.com/content/assets/sintel/poster.png',
 };
 

--- a/player/picture-in-picture/js/script.js
+++ b/player/picture-in-picture/js/script.js
@@ -25,8 +25,8 @@
   };
 
   var source = {
-    dash: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd',
     hls: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/m3u8s/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8',
+    dash: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd',
     progressive: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/MI201109210084_mpeg-4_hd_high_1080p25_10mbits.mp4',
     poster: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/poster.jpg'
   };

--- a/player/picture-in-picture/setup.js
+++ b/player/picture-in-picture/setup.js
@@ -26,8 +26,8 @@ var conf = {
 };
 
 var source = {
-  dash: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd',
   hls: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/m3u8s/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8',
+  dash: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd',
   progressive: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/MI201109210084_mpeg-4_hd_high_1080p25_10mbits.mp4',
   poster: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/poster.jpg',
 };

--- a/player/player-playground/demo.js
+++ b/player/player-playground/demo.js
@@ -3,8 +3,8 @@ var conf = {
 };
 
 var source = {
-  dash: "https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd",
   hls: "https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/m3u8s/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8",
+  dash: "https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd",
   poster: "https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/poster.jpg"
 };
 

--- a/player/player-playground/js/script.js
+++ b/player/player-playground/js/script.js
@@ -14,8 +14,8 @@ var tempKeyHolder = {
 }
 
 var sourceConfig = {
-    dash: "https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd",
     hls: "https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/m3u8s/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8",
+    dash: "https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd",
     progressive: "https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/MI201109210084_mpeg-4_hd_high_1080p25_10mbits.mp4",
     smooth: "https://test.playready.microsoft.com/smoothstreaming/SSWSS720H264/SuperSpeedway_720.ism/manifest",
     poster: "https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/poster.jpg"

--- a/player/player-ui-styling/demo.js
+++ b/player/player-ui-styling/demo.js
@@ -8,8 +8,8 @@ const conf = {
 };
 
 var source = {
-  dash: 'https://cdn.bitmovin.com/content/assets/sintel/sintel.mpd',
   hls: 'https://cdn.bitmovin.com/content/assets/sintel/hls/playlist.m3u8',
+  dash: 'https://cdn.bitmovin.com/content/assets/sintel/sintel.mpd',
   poster: 'https://cdn.bitmovin.com/content/assets/sintel/poster.png',
 };
 

--- a/player/player-ui-styling/externallyManaged.js
+++ b/player/player-ui-styling/externallyManaged.js
@@ -4,8 +4,8 @@ var config = {
 };
 
 var source = {
-  dash: 'https://cdn.bitmovin.com/content/assets/sintel/sintel.mpd',
   hls: 'https://cdn.bitmovin.com/content/assets/sintel/hls/playlist.m3u8',
+  dash: 'https://cdn.bitmovin.com/content/assets/sintel/sintel.mpd',
   poster: 'https://cdn.bitmovin.com/content/assets/sintel/poster.png'
 };
 

--- a/player/player-ui-styling/js/script.js
+++ b/player/player-ui-styling/js/script.js
@@ -11,8 +11,8 @@ var conf = {
 };
 
 var source = {
-  dash: 'https://cdn.bitmovin.com/content/assets/sintel/sintel.mpd',
   hls: 'https://cdn.bitmovin.com/content/assets/sintel/hls/playlist.m3u8',
+  dash: 'https://cdn.bitmovin.com/content/assets/sintel/sintel.mpd',
   poster: 'https://cdn.bitmovin.com/content/assets/sintel/poster.png'
 };
 

--- a/player/preload-vod/js/script.js
+++ b/player/preload-vod/js/script.js
@@ -63,8 +63,8 @@ var conf = {
 };
 
 var source = {
-  dash: 'https://cdn.bitmovin.com/content/assets/sintel/sintel.mpd',
   hls: 'https://cdn.bitmovin.com/content/assets/sintel/hls/playlist.m3u8',
+  dash: 'https://cdn.bitmovin.com/content/assets/sintel/sintel.mpd',
   poster: 'https://cdn.bitmovin.com/content/assets/sintel/poster.png'
 };
 

--- a/player/ssai/demo.js
+++ b/player/ssai/demo.js
@@ -3,8 +3,8 @@ var conf = {
 };
 
 var source = {
-  dash: 'https://bitmovin-a.akamaihd.net/498364_fcb0257026d0bd3ee0ba3aad95674188/manifest.mpd',
   hls: 'https://bitmovin-a.akamaihd.net/498364_fcb0257026d0bd3ee0ba3aad95674188/playlist.m3u8',
+  dash: 'https://bitmovin-a.akamaihd.net/498364_fcb0257026d0bd3ee0ba3aad95674188/manifest.mpd',
   poster: 'https://bitmovin-a.akamaihd.net/498364_fcb0257026d0bd3ee0ba3aad95674188/poster.jpg'
 };
 

--- a/player/ssai/js/script.js
+++ b/player/ssai/js/script.js
@@ -10,8 +10,8 @@ var conf = {
 };
 
 var source = {
-  dash: 'https://bitmovin-a.akamaihd.net/498364_fcb0257026d0bd3ee0ba3aad95674188/manifest.mpd',
   hls: 'https://bitmovin-a.akamaihd.net/498364_fcb0257026d0bd3ee0ba3aad95674188/playlist.m3u8',
+  dash: 'https://bitmovin-a.akamaihd.net/498364_fcb0257026d0bd3ee0ba3aad95674188/manifest.mpd',
   poster: 'https://bitmovin-a.akamaihd.net/498364_fcb0257026d0bd3ee0ba3aad95674188/poster.jpg',
 };
 

--- a/player/stream-test/js/script.js
+++ b/player/stream-test/js/script.js
@@ -57,16 +57,16 @@ var config = {
 };
 
 var source = {
-  dash: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd',
   hls: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/m3u8s/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8',
+  dash: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd',
   progressive: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/MI201109210084_mpeg-4_hd_high_1080p25_10mbits.mp4',
   smooth: 'https://test.playready.microsoft.com/smoothstreaming/SSWSS720H264/SuperSpeedway_720.ism/manifest',
   poster: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/poster.jpg'
 };
 
 var drmSource = {
-  dash: 'https://cdn.bitmovin.com/content/assets/art-of-motion_drm/mpds/11331.mpd',
   hls: 'https://cdn.bitmovin.com/content/assets/art-of-motion_drm/m3u8s/11331.m3u8',
+  dash: 'https://cdn.bitmovin.com/content/assets/art-of-motion_drm/mpds/11331.mpd',
   smooth: 'https://test.playready.microsoft.com/smoothstreaming/SSWSS720H264/SuperSpeedway_720.ism/manifest',
   progressive: '',
   drm: {

--- a/player/thumbnail-seeking/js/script.js
+++ b/player/thumbnail-seeking/js/script.js
@@ -10,8 +10,8 @@ var conf = {
 };
 
 var source = {
-  dash: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd',
   hls: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/m3u8s/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8',
+  dash: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd',
   progressive: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/MI201109210084_mpeg-4_hd_high_1080p25_10mbits.mp4',
   poster: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/poster.jpg',
   thumbnailTrack: {

--- a/player/thumbnail-seeking/setup.js
+++ b/player/thumbnail-seeking/setup.js
@@ -3,8 +3,8 @@ var conf = {
 };
 
 var source = {
-  dash: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd',
   hls: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/m3u8s/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8',
+  dash: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd',
   progressive: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/MI201109210084_mpeg-4_hd_high_1080p25_10mbits.mp4',
   poster: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/poster.jpg',
   thumbnailTrack: {

--- a/player/variable-playback-speed/demo.js
+++ b/player/variable-playback-speed/demo.js
@@ -3,8 +3,8 @@ var conf = {
 };
 
 var source = {
-  dash: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd',
   hls: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/m3u8s/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8',
+  dash: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd',
   progressive: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/MI201109210084_mpeg-4_hd_high_1080p25_10mbits.mp4',
   poster: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/poster.jpg'
 };

--- a/player/variable-playback-speed/js/script.js
+++ b/player/variable-playback-speed/js/script.js
@@ -13,8 +13,8 @@ var conf = {
 };
 
 var source = {
-  dash: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd',
   hls: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/m3u8s/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8',
+  dash: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd',
   progressive: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/MI201109210084_mpeg-4_hd_high_1080p25_10mbits.mp4',
   poster: 'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/poster.jpg'
 };

--- a/player/vr-360/demo.js
+++ b/player/vr-360/demo.js
@@ -6,8 +6,8 @@ var conf = {
 };
 
 var source = {
-  dash: 'https://cdn.bitmovin.com/content/assets/playhouse-vr/mpds/105560.mpd',
   hls: 'https://cdn.bitmovin.com/content/assets/playhouse-vr/m3u8s/105560.m3u8',
+  dash: 'https://cdn.bitmovin.com/content/assets/playhouse-vr/mpds/105560.mpd',
   progressive: 'https://cdn.bitmovin.com/content/assets/playhouse-vr/progressive.mp4',
   poster: 'https://cdn.bitmovin.com/content/assets/playhouse-vr/poster.jpg',
   vr: {

--- a/player/vr-360/js/script.js
+++ b/player/vr-360/js/script.js
@@ -13,8 +13,8 @@ var conf = {
 };
 
 var source = {
-  dash: 'https://cdn.bitmovin.com/content/assets/playhouse-vr/mpds/105560.mpd',
   hls: 'https://cdn.bitmovin.com/content/assets/playhouse-vr/m3u8s/105560.m3u8',
+  dash: 'https://cdn.bitmovin.com/content/assets/playhouse-vr/mpds/105560.mpd',
   progressive: 'https://cdn.bitmovin.com/content/assets/playhouse-vr/progressive.mp4',
   poster: 'https://cdn.bitmovin.com/content/assets/playhouse-vr/poster.jpg',
   vr: {


### PR DESCRIPTION
We have some problem with using dash source on safari and on iOS device in some of the demos, as dash does not work quite well or not supported at all on these devices.

Now HLS source is placed first in the source config so it will be selected automatically.

