### PR TITLE
Default HLS source in stream test demo

### DIFF
--- a/player/stream-test/index.html
+++ b/player/stream-test/index.html
@@ -22,10 +22,10 @@
                 <div class="type-header">Stream type</div>
                 <div class="demo-stream-type-input">
                     <div class="input-type">
-                        <label><input type="radio" name="stream-format" value="dash" checked> DASH</label>
+                        <label><input type="radio" name="stream-format" value="hls" checked> HLS</label>
                     </div>
                     <div class="input-type">
-                        <label><input type="radio" name="stream-format" value="hls"> HLS</label>
+                        <label><input type="radio" name="stream-format" value="dash"> DASH</label>
                     </div>
                     <div class="input-type">
                         <label><input type="radio" name="stream-format" value="smooth"> Smooth</label>


### PR DESCRIPTION
Stream test source uses Dash by default that is not supported on iOS and demo does not work.

HLS source is now selected as default.