### PR TITLE
Disable CSS PiP, when native PiP is active already

### DIFF
--- a/player/picture-in-picture/scrollListener.js
+++ b/player/picture-in-picture/scrollListener.js
@@ -5,9 +5,16 @@ function adjustPlayer() {
   const lowerEdge = container.offset().top + container.height();
   const switchToMinPlayerPos = lowerEdge - (window.innerHeight / 3);
   const currentScrollPos = document.body.scrollTop || document.documentElement.scrollTop;
+  const nativePipEnabled = player.getViewMode() === bitmovin.player.ViewMode.PictureInPicture;
+
+  /* Disable CSS PiP, if native PiP is already in use */
+  if (nativePipEnabled) {
+    document.querySelector('.player-switch').classList.remove('fixed-player');
+    return;
+  }
 
   /* toggle the css-class responsible for the player moving to the lower right corner */
-  if (currentScrollPos > switchToMinPlayerPos) {
+  if (currentScrollPos > switchToMinPlayerPos && !nativePipEnabled) {
     $('.player-switch').addClass('fixed-player');
   } else {
     $('.player-switch').removeClass('fixed-player');

--- a/player/picture-in-picture/setup.js
+++ b/player/picture-in-picture/setup.js
@@ -21,7 +21,10 @@ var conf = {
         )
         ;
       }
-    }
+    },
+    viewmodechanged: function() {
+      adjustPlayer();
+    },
   }
 };
 


### PR DESCRIPTION
Remove `fixed-player` class for CSS-based PiP, in case native PiP is … already active