### PR TITLE
[untracked] Use AoM for main content

### DIFF
--- a/player/sgai/js/script.js
+++ b/player/sgai/js/script.js
@@ -34,7 +34,8 @@ var conf = {
 };
 
 var source = {
-  hls: 'https://demo.bitmovin.com/public/sgai/aip/assets/video_1080p.m3u8',
+  hls:
+    'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/adblendr-hls-interstitials/playlist.m3u8',
 };
 
 var hidden = false;


### PR DESCRIPTION
The current main content for our SGAI / HLS Interstitial demo displays a green screen with a timestamp. It would be nicer to have actual content playing back.

This PR introduces an HLS stream that has the `AdBlendr` HLS Interstitials in, but uses _Art of Motion_ as main content.